### PR TITLE
Fix GitHub Pages deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,5 +27,5 @@ jobs:
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         publish_dir: ./docs

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ A demo page for the banking application is available, showcasing single componen
 ## **Configuration**
 
 - Update the `app_factory.py` & `DatabaseHandling\connection.py` file with your database and other environment-specific settings.
+- Ensure that the `GITHUB_TOKEN` secret is configured with write permissions for the `gh-pages` branch.
 
 ## **Contributing**
 


### PR DESCRIPTION
Update the GitHub Actions workflow to use a personal access token with write permissions for the `gh-pages` branch.

* **README.md**:
  - Add a note about configuring the `GITHUB_TOKEN` secret with write permissions for the `gh-pages` branch.

* **.github/workflows/deploy.yml**:
  - Update the `github_token` to use a personal access token with write permissions for the `gh-pages` branch.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/bankarstvo?shareId=3a704dd9-a282-40d2-8323-1b496973535a).