### PR TITLE
Fix GitHub Pages deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ A demo page for the banking application is available, showcasing single componen
 ## **Configuration**
 
 - Update the `app_factory.py` & `DatabaseHandling\connection.py` file with your database and other environment-specific settings.
+- Ensure the `GITHUB_TOKEN` secret is configured with write permissions for the `gh-pages` branch.
 
 ## **Contributing**
 


### PR DESCRIPTION
Update GitHub Actions workflow to fix permission issues for deploying to GitHub Pages.

* **README.md**
  - Add a note about configuring the `GITHUB_TOKEN` secret with write permissions for the `gh-pages` branch.

* **.github/workflows/deploy.yml**
  - Add a `permissions` section to the workflow file.
  - Set `contents: write` under the `permissions` section.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/bankarstvo?shareId=ea57b31d-c062-4a74-a12c-4299f2c2ea71).