### PR TITLE
Add comprehensive tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Banking application",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "pytest",
     "build": "sass static/css/dashboard.scss static/css/dashboard.css && webpack --config webpack.config.js"
   },
   "author": "koke1997",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --maxfail=5 --disable-warnings
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ typing_extensions==4.9.0
 urllib3==2.2.1
 Werkzeug==3.0.1
 WTForms==3.1.2
+pytest==7.4.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# This is an empty __init__.py file to mark the directory as a package.

--- a/tests/test_accountdetails.py
+++ b/tests/test_accountdetails.py
@@ -1,0 +1,23 @@
+import pytest
+from FiatHandling.accountdetails import get_account_details
+from unittest.mock import patch, MagicMock
+
+@pytest.fixture
+def mock_db_connection():
+    with patch('FiatHandling.accountdetails.connect_db') as mock_connect_db:
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_connect_db.return_value = mock_conn
+        mock_conn.cursor.return_value = mock_cursor
+        yield mock_cursor
+
+def test_get_account_details(mock_db_connection):
+    user_id = 1
+    expected_details = ('test_user', 'test_user@example.com', '2022-01-01', '2022-01-02')
+    mock_db_connection.fetchone.return_value = expected_details
+
+    details = get_account_details(user_id)
+
+    assert details == expected_details
+    mock_db_connection.execute.assert_called_once_with("SELECT username, email, account_created, last_login FROM Users WHERE user_id = %s", (user_id,))
+    mock_db_connection.close.assert_called_once()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,39 @@
+import pytest
+from flask import Flask
+from app_factory import create_app
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config.update({
+        "TESTING": True,
+    })
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+@pytest.fixture
+def runner(app):
+    return app.test_cli_runner()
+
+def test_index(client):
+    response = client.get("/")
+    assert response.status_code == 200
+    assert b"Welcome to the Banking App" in response.data
+
+def test_docs(client):
+    response = client.get("/docs")
+    assert response.status_code == 200
+    assert b"Documentation" in response.data
+
+def test_404(client):
+    response = client.get("/nonexistent")
+    assert response.status_code == 404
+    assert b"404 Not Found" in response.data
+
+def test_error_handler(client):
+    response = client.get("/error")
+    assert response.status_code == 500
+    assert b"An error occurred" in response.data

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,0 +1,43 @@
+import pytest
+from app_factory import create_app
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config.update({
+        "TESTING": True,
+    })
+    yield app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+@pytest.fixture
+def runner(app):
+    return app.test_cli_runner()
+
+def test_app_creation(app):
+    assert app is not None
+    assert app.config["TESTING"] is True
+
+def test_index_route(client):
+    response = client.get("/")
+    assert response.status_code == 200
+    assert b"Welcome" in response.data
+
+def test_docs_route(client):
+    response = client.get("/docs")
+    assert response.status_code == 200
+    assert b"Documentation" in response.data
+
+def test_404_error_handler(client):
+    response = client.get("/nonexistent")
+    assert response.status_code == 404
+    assert b"404 Not Found" in response.data
+
+def test_500_error_handler(client):
+    with pytest.raises(Exception):
+        response = client.get("/error")
+        assert response.status_code == 500
+        assert b"An error occurred" in response.data

--- a/tests/test_balancecheck.py
+++ b/tests/test_balancecheck.py
@@ -1,0 +1,32 @@
+import pytest
+from DatabaseHandling.balancecheck import get_user_balance, check_balance
+from core.models import User
+
+@pytest.fixture
+def mock_user(mocker):
+    user = User(email="test@example.com", balance=100.0)
+    mocker.patch('core.models.User.query.filter_by', return_value=mocker.Mock(first=lambda: user))
+    return user
+
+def test_get_user_balance(mock_user):
+    balance = get_user_balance("test@example.com")
+    assert balance == 100.0
+
+def test_get_user_balance_no_user(mocker):
+    mocker.patch('core.models.User.query.filter_by', return_value=mocker.Mock(first=lambda: None))
+    balance = get_user_balance("nonexistent@example.com")
+    assert balance is None
+
+def test_check_balance(mocker):
+    mock_cursor = mocker.Mock()
+    mock_cursor.fetchone.return_value = (200.0,)
+    mocker.patch('DatabaseHandling.balancecheck.connect_db', return_value=mocker.Mock(cursor=lambda: mock_cursor))
+    balance = check_balance(1)
+    assert balance == 200.0
+
+def test_check_balance_no_result(mocker):
+    mock_cursor = mocker.Mock()
+    mock_cursor.fetchone.return_value = None
+    mocker.patch('DatabaseHandling.balancecheck.connect_db', return_value=mocker.Mock(cursor=lambda: mock_cursor))
+    balance = check_balance(1)
+    assert balance is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,49 @@
+import pytest
+import subprocess
+import os
+import signal
+import psutil
+import logging
+from unittest.mock import patch, mock_open
+
+logger = logging.getLogger(__name__)
+
+PID_FILE = 'app.pid'
+
+def test_start_app():
+    with patch('subprocess.Popen') as mock_popen:
+        mock_popen.return_value.pid = 1234
+        with patch('builtins.open', mock_open()) as mock_file:
+            start_app()
+            mock_popen.assert_called_once_with([os.path.join(os.path.dirname(sys.executable), 'python'), "app.py"], creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
+            mock_file.assert_called_once_with(PID_FILE, 'w')
+            mock_file().write.assert_called_once_with('1234')
+
+def test_stop_app():
+    with patch('builtins.open', mock_open(read_data='1234')) as mock_file:
+        with patch('psutil.Process') as mock_process:
+            mock_process.return_value.children.return_value = []
+            stop_app()
+            mock_process.assert_called_once_with(1234)
+            mock_process.return_value.kill.assert_called_once()
+            mock_file().close.assert_called_once()
+
+def test_restart_app():
+    with patch('builtins.open', mock_open(read_data='1234')) as mock_file:
+        with patch('psutil.Process') as mock_process:
+            mock_process.return_value.children.return_value = []
+            with patch('subprocess.Popen') as mock_popen:
+                mock_popen.return_value.pid = 1234
+                restart_app()
+                mock_process.assert_called_once_with(1234)
+                mock_process.return_value.kill.assert_called_once()
+                mock_popen.assert_called_once_with([os.path.join(os.path.dirname(sys.executable), 'python'), "app.py"], creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
+                mock_file().write.assert_called_once_with('1234')
+
+def test_status_app():
+    with patch('builtins.open', mock_open(read_data='1234')) as mock_file:
+        with patch('psutil.pid_exists') as mock_pid_exists:
+            mock_pid_exists.return_value = True
+            status_app()
+            mock_pid_exists.assert_called_once_with(1234)
+            mock_file().close.assert_called_once()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,27 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from DatabaseHandling.connection import connect_db, get_db_cursor
+
+@patch('DatabaseHandling.connection.pool.get_connection')
+def test_connect_db(mock_get_connection):
+    mock_connection = MagicMock()
+    mock_get_connection.return_value = mock_connection
+
+    connection = connect_db()
+
+    assert connection == mock_connection
+    mock_get_connection.assert_called_once()
+
+@patch('DatabaseHandling.connection.connect_db')
+def test_get_db_cursor(mock_connect_db):
+    mock_connection = MagicMock()
+    mock_cursor = MagicMock()
+    mock_connection.cursor.return_value = mock_cursor
+    mock_connect_db.return_value = mock_connection
+
+    connection, cursor = get_db_cursor()
+
+    assert connection == mock_connection
+    assert cursor == mock_cursor
+    mock_connect_db.assert_called_once()
+    mock_connection.cursor.assert_called_once_with(dictionary=True)

--- a/tests/test_create_account.py
+++ b/tests/test_create_account.py
@@ -1,0 +1,58 @@
+import pytest
+from flask import url_for
+from flask_login import login_user
+from routes.account_routes.create_account import create_account
+from DatabaseHandling.connection import get_db_cursor
+from app_factory import create_app
+from utils.extensions import db
+from core.models import User, Account
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config.update({
+        "TESTING": True,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+    })
+
+    with app.app_context():
+        db.create_all()
+        yield app
+
+    with app.app_context():
+        db.drop_all()
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+@pytest.fixture
+def runner(app):
+    return app.test_cli_runner()
+
+@pytest.fixture
+def user(app):
+    with app.app_context():
+        user = User(username="testuser", email="testuser@example.com", password_hash="hashedpassword")
+        db.session.add(user)
+        db.session.commit()
+        return user
+
+def test_create_account(client, user):
+    with client:
+        login_user(user)
+        response = client.post(url_for("account_routes.create_account"), data={
+            "account_name": "Test Account",
+            "account_type": "checking",
+            "currency_code": "USD"
+        })
+        assert response.status_code == 302  # Redirects to dashboard
+        assert b"Account created successfully!" in response.data
+
+        with get_db_cursor() as cursor:
+            cursor.execute("SELECT * FROM accounts WHERE user_id = ?", (user.id,))
+            account = cursor.fetchone()
+            assert account is not None
+            assert account["account_name"] == "Test Account"
+            assert account["account_type"] == "checking"
+            assert account["currency_code"] == "USD"

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,70 @@
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+from routes.transaction_routes.crypto import crypto_routes, get_user_balance, update_user_balance
+from core.models import CryptoAsset
+from utils.extensions import db
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db.init_app(app)
+    app.register_blueprint(crypto_routes)
+    with app.app_context():
+        db.create_all()
+    yield app
+    with app.app_context():
+        db.drop_all()
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+def test_buy_crypto(client: FlaskClient):
+    user_id = 1
+    symbol = 'bitcoin'
+    amount = 1.0
+
+    # Mock the get_user_balance and update_user_balance functions
+    def mock_get_user_balance(user_id):
+        return 100000.0
+
+    def mock_update_user_balance(user_id, new_balance):
+        pass
+
+    # Replace the real functions with the mock functions
+    crypto_routes.get_user_balance = mock_get_user_balance
+    crypto_routes.update_user_balance = mock_update_user_balance
+
+    response = client.post('/crypto/buy', json={'user_id': user_id, 'symbol': symbol, 'amount': amount})
+    assert response.status_code == 200
+    assert response.json['message'] == 'Crypto purchased successfully'
+
+def test_sell_crypto(client: FlaskClient):
+    user_id = 1
+    symbol = 'bitcoin'
+    amount = 1.0
+
+    # Mock the get_user_balance and update_user_balance functions
+    def mock_get_user_balance(user_id):
+        return 100000.0
+
+    def mock_update_user_balance(user_id, new_balance):
+        pass
+
+    # Replace the real functions with the mock functions
+    crypto_routes.get_user_balance = mock_get_user_balance
+    crypto_routes.update_user_balance = mock_update_user_balance
+
+    # Add a crypto asset to the database
+    with client.application.app_context():
+        crypto_asset = CryptoAsset(user_id=user_id, symbol=symbol, balance=amount)
+        db.session.add(crypto_asset)
+        db.session.commit()
+
+    response = client.post('/crypto/sell', json={'user_id': user_id, 'symbol': symbol, 'amount': amount})
+    assert response.status_code == 200
+    assert response.json['message'] == 'Crypto sold successfully'

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,76 @@
+import pytest
+from flask import session, url_for
+from flask_login import login_user
+from routes.account_routes.dashboard import dashboard
+from DatabaseHandling.connection import get_db_cursor
+from app_factory import create_app
+from utils.extensions import db
+from core.models import User, Account
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config.update({
+        "TESTING": True,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+    })
+
+    with app.app_context():
+        db.create_all()
+        yield app
+
+    with app.app_context():
+        db.drop_all()
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+@pytest.fixture
+def runner(app):
+    return app.test_cli_runner()
+
+@pytest.fixture
+def user(app):
+    with app.app_context():
+        user = User(username="testuser", email="testuser@example.com", password_hash="hashedpassword")
+        db.session.add(user)
+        db.session.commit()
+        return user
+
+def test_dashboard_access(client, user):
+    with client:
+        login_user(user)
+        response = client.get(url_for("account_routes.dashboard"))
+        assert response.status_code == 200
+        assert b"Dashboard" in response.data
+
+def test_dashboard_account_selection(client, user):
+    with client:
+        login_user(user)
+        response = client.post(url_for("account_routes.dashboard"), data={
+            "account_choice": 1
+        })
+        assert response.status_code == 200
+        assert session.get("selected_account_id") == 1
+
+def test_dashboard_search(client, user):
+    with client:
+        login_user(user)
+        response = client.post(url_for("account_routes.dashboard"), data={
+            "search_button": "search",
+            "recipient": "testuser"
+        })
+        assert response.status_code == 200
+        assert b"Search Results" in response.data
+
+def test_dashboard_transfer(client, user):
+    with client:
+        login_user(user)
+        response = client.post(url_for("account_routes.dashboard"), data={
+            "transfer_button": "transfer",
+            "amount": 100,
+            "recipient_account_id": 2
+        })
+        assert response.status_code == 200
+        assert b"Transfer successful!" in response.data

--- a/tests/test_deposit.py
+++ b/tests/test_deposit.py
@@ -1,0 +1,44 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from FiatHandling.deposit import deposit
+
+@pytest.fixture
+def mock_db():
+    with patch('FiatHandling.deposit.connect_db') as mock_connect_db:
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_connect_db.return_value = mock_conn
+        mock_conn.cursor.return_value = mock_cursor
+        yield mock_cursor
+
+def test_deposit_success(mock_db):
+    mock_db.fetchone.side_effect = [(1,), (1,)]
+    mock_db.execute.return_value = None
+
+    result = deposit(1, 100, 'USD')
+    assert result == "Deposit successful"
+    mock_db.execute.assert_called_with("UPDATE accounts SET balance = balance + %s WHERE account_id = %s", (100, 1))
+
+def test_deposit_invalid_currency(mock_db):
+    with patch('FiatHandling.deposit.validate_currency', return_value=False):
+        result = deposit(1, 100, 'INVALID')
+        assert result == "Invalid currency code"
+
+def test_deposit_account_not_found(mock_db):
+    mock_db.fetchone.side_effect = [None]
+
+    result = deposit(1, 100, 'USD')
+    assert result == "Account not found for user with given currency"
+
+def test_deposit_invalid_account(mock_db):
+    mock_db.fetchone.side_effect = [(1,)]
+    with patch('FiatHandling.deposit.validate_account', return_value=False):
+        result = deposit(1, 100, 'USD')
+        assert result == "Invalid account"
+
+def test_deposit_db_error(mock_db):
+    mock_db.execute.side_effect = Exception("DB Error")
+    mock_db.fetchone.side_effect = [(1,), (1,)]
+
+    result = deposit(1, 100, 'USD')
+    assert "An error occurred" in result

--- a/tests/test_fundtransfer.py
+++ b/tests/test_fundtransfer.py
@@ -1,0 +1,45 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from FiatHandling.fundtransfer import transfer
+
+@pytest.fixture
+def mock_db():
+    with patch('FiatHandling.fundtransfer.connect_db') as mock_connect_db:
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_connect_db.return_value = mock_conn
+        mock_conn.cursor.return_value = mock_cursor
+        yield mock_cursor
+
+def test_transfer_success(mock_db):
+    mock_db.fetchone.side_effect = [
+        (1, 1000),  # Sender's account and balance
+        None,       # Receiver's account validation
+        None        # Log transaction
+    ]
+
+    result = transfer(1, 2, 100, 'USD')
+    assert result == "Transfer successful"
+    mock_db.execute.assert_any_call("UPDATE accounts SET balance = balance - %s WHERE account_id = %s", (100, 1))
+    mock_db.execute.assert_any_call("UPDATE accounts SET balance = balance + %s WHERE account_id = %s", (100, 2))
+
+def test_transfer_insufficient_funds(mock_db):
+    mock_db.fetchone.side_effect = [
+        (1, 50),  # Sender's account and balance
+    ]
+
+    result = transfer(1, 2, 100, 'USD')
+    assert result == "Insufficient funds"
+
+def test_transfer_invalid_currency(mock_db):
+    result = transfer(1, 2, 100, 'INVALID')
+    assert result == "Invalid currency code."
+
+def test_transfer_invalid_receiver_account(mock_db):
+    mock_db.fetchone.side_effect = [
+        (1, 1000),  # Sender's account and balance
+        None        # Receiver's account validation
+    ]
+
+    result = transfer(1, 999, 100, 'USD')
+    assert result == "Receiver's account is invalid."

--- a/tests/test_get_balance.py
+++ b/tests/test_get_balance.py
@@ -1,0 +1,23 @@
+import pytest
+from flask import session
+from DatabaseHandling.connection import get_db_cursor
+from routes.account_routes.get_balance import get_balance
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+def test_get_balance(client):
+    with client.session_transaction() as sess:
+        sess["selected_account_id"] = 1
+
+    response = client.get("/get_balance")
+    assert response.status_code == 200
+    assert "balance" in response.json
+    assert response.json["balance"] == 100.00  # Replace with the expected balance for account_id 1
+
+def test_get_balance_no_account_selected(client):
+    response = client.get("/get_balance")
+    assert response.status_code == 400
+    assert "error" in response.json
+    assert response.json["error"] == "No account selected"

--- a/tests/test_plot_diagram.py
+++ b/tests/test_plot_diagram.py
@@ -1,0 +1,55 @@
+import pytest
+from core.plot_diagram import plot_routes_diagram, extract_routes_from_file, extract_all_routes, plot_detailed_routes_diagram
+
+def test_extract_routes_from_file():
+    # Create a temporary file with some routes
+    with open('temp_routes.py', 'w') as f:
+        f.write("""
+@account_routes.route('/dashboard', methods=['GET', 'POST'])
+def dashboard():
+    pass
+
+@account_routes.route('/create_account', methods=['GET', 'POST'])
+def create_account():
+    pass
+        """)
+
+    routes = extract_routes_from_file('temp_routes.py')
+    assert len(routes) == 2
+    assert routes[0] == "@account_routes.route('/dashboard', methods=['GET', 'POST'])"
+    assert routes[1] == "@account_routes.route('/create_account', methods=['GET', 'POST'])"
+
+def test_extract_all_routes(monkeypatch):
+    def mock_extract_routes_from_file(file_path):
+        if file_path == 'routes/account_routes.py':
+            return [
+                "@account_routes.route('/dashboard', methods=['GET', 'POST'])",
+                "@account_routes.route('/create_account', methods=['GET', 'POST'])"
+            ]
+        return []
+
+    monkeypatch.setattr('core.plot_diagram.extract_routes_from_file', mock_extract_routes_from_file)
+
+    extracted_routes = extract_all_routes()
+    assert len(extracted_routes) == 3
+    assert len(extracted_routes['account_routes.py']) == 2
+
+def test_plot_routes_diagram():
+    extracted_routes = {
+        'account_routes.py': [
+            "@account_routes.route('/dashboard', methods=['GET', 'POST'])",
+            "@account_routes.route('/create_account', methods=['GET', 'POST'])"
+        ]
+    }
+    plot_routes_diagram(extracted_routes)
+    # No assertion needed, just ensure no exceptions are raised
+
+def test_plot_detailed_routes_diagram():
+    extracted_routes = {
+        'account_routes.py': [
+            "@account_routes.route('/dashboard', methods=['GET', 'POST'])",
+            "@account_routes.route('/create_account', methods=['GET', 'POST'])"
+        ]
+    }
+    plot_detailed_routes_diagram(extracted_routes)
+    # No assertion needed, just ensure no exceptions are raised

--- a/tests/test_registration_func.py
+++ b/tests/test_registration_func.py
@@ -1,0 +1,25 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from DatabaseHandling.registration_func import register_user
+from core.models import User
+
+@pytest.fixture
+def mock_user(mocker):
+    user = User(username="testuser", email="test@example.com", password_hash="hashedpassword")
+    mocker.patch('core.models.User.query.filter_by', return_value=mocker.Mock(first=lambda: user))
+    return user
+
+def test_register_user_success(mocker):
+    mocker.patch('core.models.User.query.filter_by', return_value=mocker.Mock(first=lambda: None))
+    mocker.patch('utils.extensions.db.session.add')
+    mocker.patch('utils.extensions.db.session.commit')
+    mocker.patch('utils.extensions.bcrypt.generate_password_hash', return_value="hashedpassword")
+
+    new_user = register_user("newuser", "new@example.com", "password")
+    assert new_user.username == "newuser"
+    assert new_user.email == "new@example.com"
+    assert new_user.password_hash == "hashedpassword"
+
+def test_register_user_existing_user(mock_user):
+    result = register_user("testuser", "test@example.com", "password")
+    assert result is False

--- a/tests/test_select_account.py
+++ b/tests/test_select_account.py
@@ -1,0 +1,54 @@
+import pytest
+from flask import session, url_for
+from flask_login import login_user
+from routes.account_routes.select_account import select_account
+from DatabaseHandling.connection import get_db_cursor
+from app_factory import create_app
+from utils.extensions import db
+from core.models import User, Account
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config.update({
+        "TESTING": True,
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+    })
+
+    with app.app_context():
+        db.create_all()
+        yield app
+
+    with app.app_context():
+        db.drop_all()
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+@pytest.fixture
+def runner(app):
+    return app.test_cli_runner()
+
+@pytest.fixture
+def user(app):
+    with app.app_context():
+        user = User(username="testuser", email="testuser@example.com", password_hash="hashedpassword")
+        db.session.add(user)
+        db.session.commit()
+        return user
+
+def test_select_account(client, user):
+    with client:
+        login_user(user)
+        response = client.post(url_for("account_routes.select_account"), data={
+            "account_choice": 1
+        })
+        assert response.status_code == 302  # Redirects to dashboard
+        assert session.get("selected_account_id") == 1
+
+        with get_db_cursor() as cursor:
+            cursor.execute("SELECT * FROM accounts WHERE account_id = ?", (1,))
+            account = cursor.fetchone()
+            assert account is not None
+            assert account["account_id"] == 1

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -1,0 +1,82 @@
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+from unittest.mock import patch, MagicMock
+from routes.transaction_routes.stock import buy_stock, sell_stock
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+
+    with app.test_client() as client:
+        yield client
+
+def test_buy_stock_success(client):
+    data = {
+        'user_id': 1,
+        'symbol': 'AAPL',
+        'shares': 10
+    }
+
+    with patch('routes.transaction_routes.stock.get_user_balance', return_value=10000):
+        with patch('routes.transaction_routes.stock.update_user_balance') as mock_update_balance:
+            with patch('routes.transaction_routes.stock.requests.get') as mock_get:
+                mock_get.return_value.json.return_value = {'price': 100}
+
+                response = client.post('/stock/buy', json=data)
+                assert response.status_code == 200
+                assert response.json['message'] == 'Stock purchased successfully'
+                mock_update_balance.assert_called_once()
+
+def test_buy_stock_insufficient_balance(client):
+    data = {
+        'user_id': 1,
+        'symbol': 'AAPL',
+        'shares': 10
+    }
+
+    with patch('routes.transaction_routes.stock.get_user_balance', return_value=500):
+        with patch('routes.transaction_routes.stock.requests.get') as mock_get:
+            mock_get.return_value.json.return_value = {'price': 100}
+
+            response = client.post('/stock/buy', json=data)
+            assert response.status_code == 400
+            assert response.json['error'] == 'Insufficient balance'
+
+def test_sell_stock_success(client):
+    data = {
+        'user_id': 1,
+        'symbol': 'AAPL',
+        'shares': 5
+    }
+
+    with patch('routes.transaction_routes.stock.get_user_balance', return_value=10000):
+        with patch('routes.transaction_routes.stock.update_user_balance') as mock_update_balance:
+            with patch('routes.transaction_routes.stock.requests.get') as mock_get:
+                mock_get.return_value.json.return_value = {'price': 100}
+                with patch('routes.transaction_routes.stock.StockAsset.query.filter_by') as mock_query:
+                    mock_asset = MagicMock()
+                    mock_asset.shares = 10
+                    mock_query.return_value.first.return_value = mock_asset
+
+                    response = client.post('/stock/sell', json=data)
+                    assert response.status_code == 200
+                    assert response.json['message'] == 'Stock sold successfully'
+                    mock_update_balance.assert_called_once()
+
+def test_sell_stock_insufficient_balance(client):
+    data = {
+        'user_id': 1,
+        'symbol': 'AAPL',
+        'shares': 10
+    }
+
+    with patch('routes.transaction_routes.stock.requests.get') as mock_get:
+        mock_get.return_value.json.return_value = {'price': 100}
+        with patch('routes.transaction_routes.stock.StockAsset.query.filter_by') as mock_query:
+            mock_query.return_value.first.return_value = None
+
+            response = client.post('/stock/sell', json=data)
+            assert response.status_code == 400
+            assert response.json['error'] == 'Insufficient stock balance'

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1,0 +1,79 @@
+import pytest
+from flask import Flask, session
+from flask.testing import FlaskClient
+from routes.transaction_routes.transfer import transfer
+from DatabaseHandling.connection import get_db_cursor
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.secret_key = 'test_secret_key'
+    app.register_blueprint(transfer)
+    return app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+def test_transfer_success(client: FlaskClient):
+    with client.session_transaction() as sess:
+        sess['selected_account_id'] = 1
+
+    data = {
+        'amount': 100.0,
+        'recipient_account_id': 2
+    }
+
+    with patch('routes.transaction_routes.transfer.get_db_cursor') as mock_get_db_cursor:
+        mock_cursor = MagicMock()
+        mock_get_db_cursor.return_value = (MagicMock(), mock_cursor)
+        mock_cursor.fetchone.side_effect = [{'balance': 200.0}, {'balance': 100.0}]
+
+        response = client.post('/transfer', data=data)
+        assert response.status_code == 200
+        assert b'Transfer successful!' in response.data
+
+def test_transfer_insufficient_balance(client: FlaskClient):
+    with client.session_transaction() as sess:
+        sess['selected_account_id'] = 1
+
+    data = {
+        'amount': 300.0,
+        'recipient_account_id': 2
+    }
+
+    with patch('routes.transaction_routes.transfer.get_db_cursor') as mock_get_db_cursor:
+        mock_cursor = MagicMock()
+        mock_get_db_cursor.return_value = (MagicMock(), mock_cursor)
+        mock_cursor.fetchone.side_effect = [{'balance': 200.0}, {'balance': 100.0}]
+
+        response = client.post('/transfer', data=data)
+        assert response.status_code == 200
+        assert b'Insufficient balance for transfer!' in response.data
+
+def test_transfer_invalid_recipient_account(client: FlaskClient):
+    with client.session_transaction() as sess:
+        sess['selected_account_id'] = 1
+
+    data = {
+        'amount': 100.0,
+        'recipient_account_id': 'invalid'
+    }
+
+    response = client.post('/transfer', data=data)
+    assert response.status_code == 200
+    assert b'Invalid recipient account ID' in response.data
+
+def test_transfer_invalid_amount(client: FlaskClient):
+    with client.session_transaction() as sess:
+        sess['selected_account_id'] = 1
+
+    data = {
+        'amount': 'invalid',
+        'recipient_account_id': 2
+    }
+
+    response = client.post('/transfer', data=data)
+    assert response.status_code == 200
+    assert b'Invalid transfer amount' in response.data

--- a/tests/test_withdraw.py
+++ b/tests/test_withdraw.py
@@ -1,0 +1,45 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from FiatHandling.withdraw import withdraw
+
+@pytest.fixture
+def mock_db():
+    with patch('FiatHandling.withdraw.connect_db') as mock_connect_db:
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_connect_db.return_value = mock_conn
+        mock_conn.cursor.return_value = mock_cursor
+        yield mock_cursor
+
+def test_withdraw_success(mock_db):
+    mock_db.fetchone.side_effect = [(1,), (1000,)]
+    mock_db.execute.return_value = None
+
+    result = withdraw(1, 100)
+    assert result == "Withdrawal successful"
+    mock_db.execute.assert_called_with("UPDATE accounts SET balance = balance - %s WHERE account_id = %s", (100, 1))
+
+def test_withdraw_account_not_found(mock_db):
+    mock_db.fetchone.side_effect = [None]
+
+    result = withdraw(1, 100)
+    assert result == "Account not found for user"
+
+def test_withdraw_invalid_account(mock_db):
+    mock_db.fetchone.side_effect = [(1,)]
+    with patch('FiatHandling.withdraw.validate_account', return_value=False):
+        result = withdraw(1, 100)
+        assert result == "Invalid account"
+
+def test_withdraw_insufficient_balance(mock_db):
+    mock_db.fetchone.side_effect = [(1,), (50,)]
+
+    result = withdraw(1, 100)
+    assert result == "Insufficient balance for withdrawal"
+
+def test_withdraw_db_error(mock_db):
+    mock_db.execute.side_effect = Exception("DB Error")
+    mock_db.fetchone.side_effect = [(1,), (1000,)]
+
+    result = withdraw(1, 100)
+    assert "An error occurred" in result


### PR DESCRIPTION
Add comprehensive tests for the banking application.

* **Dependencies and Configuration**
  - Add `pytest` as a dependency in `requirements.txt`.
  - Add `pytest` configuration in `pytest.ini`.
  - Update `package.json` to include a test script using `pytest`.

* **Test Files**
  - Add `tests/__init__.py` to mark the directory as a package.
  - Add unit tests for `app_factory.py` in `tests/test_app_factory.py`.
  - Add unit tests for `app.py` in `tests/test_app.py`.
  - Add unit tests for `cli.py` in `tests/test_cli.py`.
  - Add unit tests for `core/plot_diagram.py` in `tests/test_plot_diagram.py`.
  - Add unit tests for `DatabaseHandling/balancecheck.py` in `tests/test_balancecheck.py`.
  - Add unit tests for `DatabaseHandling/connection.py` in `tests/test_connection.py`.
  - Add unit tests for `DatabaseHandling/registration_func.py` in `tests/test_registration_func.py`.
  - Add unit tests for `FiatHandling/accountdetails.py` in `tests/test_accountdetails.py`.
  - Add unit tests for `FiatHandling/deposit.py` in `tests/test_deposit.py`.
  - Add unit tests for `FiatHandling/fundtransfer.py` in `tests/test_fundtransfer.py`.
  - Add unit tests for `FiatHandling/withdraw.py` in `tests/test_withdraw.py`.
  - Add unit tests for `routes/account_routes/create_account.py` in `tests/test_create_account.py`.
  - Add unit tests for `routes/account_routes/dashboard.py` in `tests/test_dashboard.py`.
  - Add unit tests for `routes/account_routes/get_balance.py` in `tests/test_get_balance.py`.
  - Add unit tests for `routes/account_routes/select_account.py` in `tests/test_select_account.py`.
  - Add unit tests for `routes/transaction_routes/crypto.py` in `tests/test_crypto.py`.
  - Add unit tests for `routes/transaction_routes/stock.py` in `tests/test_stock.py`.
  - Add unit tests for `routes/transaction_routes/transfer.py` in `tests/test_transfer.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/koke1997/bankarstvo?shareId=98794f8d-944d-4d1d-9e4c-f91ed5e648c7).